### PR TITLE
2015 CPAN PR Challenge - PR #2 - Use HTTP::Status instead of hard-coding numbers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,14 @@ Plack::Session::State::URI - uri-based session state
 # SYNOPSIS
 
     use File::Temp qw/tempdir/;
+    use HTTP::Status qw/HTTP_OK/;
     use Plack::Builder;
     use Plack::Session::Store::File;
     use Plack::Session::State::URI;
 
     my $app = sub {
         return [
-            200,
+            HTTP_OK,
             ['Content-Type' => 'text/plain'],
             ['Hello Foo']
         ];

--- a/lib/Plack/Session/State/URI.pm
+++ b/lib/Plack/Session/State/URI.pm
@@ -6,6 +6,7 @@ use warnings;
 
 use Encode ();
 use HTML::StickyQuery;
+use HTTP::Status qw/HTTP_FOUND HTTP_OK/;
 use Plack::Request;
 use Plack::Util;
 
@@ -23,9 +24,9 @@ sub finalize {
 
     return unless $id;
 
-    if ($res->[0] == 200) {
+    if ($res->[0] == HTTP_OK) {
         $self->html_filter($id, $res);
-    } elsif ($res->[0] == 302) {
+    } elsif ($res->[0] == HTTP_FOUND) {
         $self->redirect_filter($id, $res);
     }
 }
@@ -109,13 +110,14 @@ Plack::Session::State::URI - uri-based session state
 =head1 SYNOPSIS
 
   use File::Temp qw/tempdir/;
+  use HTML::Status qw/HTTP_OK/;
   use Plack::Builder;
   use Plack::Session::Store::File;
   use Plack::Session::State::URI;
 
   my $app = sub {
       return [
-          200,
+          HTTP_OK,
           ['Content-Type' => 'text/plain'],
           ['Hello Foo']
       ];

--- a/t/01_uri.t
+++ b/t/01_uri.t
@@ -3,6 +3,7 @@ use warnings;
 
 use File::Temp;
 use HTTP::Request::Common;
+use HTTP::Status qw/HTTP_FOUND HTTP_OK/;
 use Plack::Builder;
 use Plack::Request;
 use Plack::Session::State::URI;
@@ -37,13 +38,13 @@ my $app = builder {
 
         if (my $url = $req->param('url')) {
             [
-                302,
+                HTTP_FOUND,
                 ['Location', $url],
                 ['']
             ];
         } else {
             [
-                200,
+                HTTP_OK,
                 ['Content-Type', 'text/html; charset="UTF-8"'],
                 [qq{<a href="/?foo=1">ok</a><p>$data</p>}]
             ]


### PR DESCRIPTION
This is a very short branch that I have rebased onto my tidy branch. There should only be one commit to merge from this pull request! The only changes that it introduces are replacing hard-coded HTTP status codes with HTTP::Status constants. I'm not sure if this makes things better or worse, which is why it's in a separate branch from the tidy branch. It might not be worth an additional dependency (Http::Status), and it probably doesn't make things all that much more clear. I'm not even sure if the status names are standardized or not.

If you do decide to merge this branch you should do it after the tidy branch because I have rebased it onto my tidy branch. If you have any trouble merging I'd be happy to rebase it for you. Just contact me! Thanks.
